### PR TITLE
Fix documentation & initializer typos

### DIFF
--- a/docs/Initializer/assets/script.js
+++ b/docs/Initializer/assets/script.js
@@ -51,7 +51,7 @@ var toast = Toaststrap.initialize({
   // Customization
   noHeader: ${formValues.noHeader ? true : false},
   dismissible: ${formValues.dismissible === "true" ? true : false},
-  pauseable: ${formValues.pauseable === "true" ? true : false},
+  pausable: ${formValues.pausable === "true" ? true : false},
   progress: ${formValues.progress},
   
   // Parent node

--- a/docs/Initializer/index.html
+++ b/docs/Initializer/index.html
@@ -72,7 +72,7 @@
                       <option value="WARNING" class="bg-warning text-dark">Warning</option>
                       <option value="DANGER" class="bg-danger text-light">Danger</option>
                       <option value="DARK" class="bg-dark text-light">Dark</option>
-                      <option value="SWEET" class="bg-dark text-light">Sweet</option>
+                      <option value="SWEET" class="bg-sweet text-light">Sweet</option>
                     </select>
                   </div>
 

--- a/docs/Initializer/index.html
+++ b/docs/Initializer/index.html
@@ -152,7 +152,7 @@
                   </div>
 
                   <div class="form-check mt-3">
-                    <label for="pausable" class="form-check-label">Pauseable?</label>
+                    <label for="pausable" class="form-check-label">Pausable?</label>
                     <input type="hidden" value="false" name="pausable">
                     <input type="checkbox" name="pausable" id="pausable"
                            class="form-check-input" value="true" checked>

--- a/docs/index.html
+++ b/docs/index.html
@@ -444,7 +444,7 @@ const MyComponent = (props) => {
               <td>Show the close button in the header.</td>
             </tr>
             <tr>
-              <td><code>pauseable</code></td>
+              <td><code>pausable</code></td>
               <td>1.0</td>
               <td><code>boolean</code></td>
               <td><code>no</code></td>


### PR DESCRIPTION
**Pauseable** isn't an option. **Pausable** is the available one.

- [X] Fix the option in the documentation
- [X] Fix *pausable?* option in the initializer
- [X] Fix initializer *type?* options' color